### PR TITLE
PE-234 - Add Amazon CloudFront signed URLs endpoint.

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,3 +3,5 @@
 Django<2.0
 pylint==1.9.3
 pycodestyle==2.5.0
+cryptography==2.4.2
+botocore==1.8.17

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,18 +4,22 @@
 #
 #    pip-compile --output-file=requirements/base.txt requirements/base.in
 #
+asn1crypto==1.2.0         # via cryptography
 astroid==1.6.6            # via pylint
-backports.functools-lru-cache==1.5  # via astroid, isort, pylint
-configparser==3.7.4       # via pylint
-django==1.11.22
-enum34==1.1.6             # via astroid
-futures==3.2.0            # via isort
+botocore==1.8.17
+cffi==1.13.2              # via cryptography
+cryptography==2.4.2
+django==1.11.26
+docutils==0.15.2          # via botocore
+idna==2.8                 # via cryptography
 isort==4.3.21             # via pylint
-lazy-object-proxy==1.4.1  # via astroid
+jmespath==0.9.4           # via botocore
+lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 pycodestyle==2.5.0
+pycparser==2.19           # via cffi
 pylint==1.9.3
-pytz==2019.1              # via django
-singledispatch==3.4.0.3   # via astroid, pylint
-six==1.12.0               # via astroid, pylint, singledispatch
+python-dateutil==2.8.1    # via botocore
+pytz==2019.3              # via django
+six==1.13.0               # via astroid, cryptography, pylint, python-dateutil
 wrapt==1.11.2             # via astroid

--- a/secure_cloudfront_video/apps.py
+++ b/secure_cloudfront_video/apps.py
@@ -17,13 +17,13 @@ class SecureCloudfrontVideoConfig(AppConfig):
     plugin_app = {
         'url_config': {
             'lms.djangoapp': {
-                'namespace': 'secure_cloudfront_video',
-                'regex': r'^secure_cloudfront_video/',
+                'namespace': 'secure-cloudfront-video',
+                'regex': r'^secure-cloudfront-video/',
                 'relative_path': 'urls',
             },
             'cms.djangoapp': {
-                'namespace': 'secure_cloudfront_video',
-                'regex': r'^secure_cloudfront_video/',
+                'namespace': 'secure-cloudfront-video',
+                'regex': r'^secure-cloudfront-video/',
                 'relative_path': 'urls',
             }
         },

--- a/secure_cloudfront_video/exceptions.py
+++ b/secure_cloudfront_video/exceptions.py
@@ -1,0 +1,10 @@
+"""
+Module containing common Exceptions for secure-cloudfront-video.
+"""
+
+class MissingCloudFrontInformationError(Exception):
+    """
+    Exception class raised when some of the required information
+    by Amazon CloudFront were not provided.
+    """
+    pass

--- a/secure_cloudfront_video/settings/common.py
+++ b/secure_cloudfront_video/settings/common.py
@@ -39,4 +39,6 @@ def plugin_settings(settings):
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    pass
+    settings.SCV_CLOUDFRONT_ID = ''
+    settings.SCV_CLOUDFRONT_URL = ''
+    settings.SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY = ''

--- a/secure_cloudfront_video/settings/production.py
+++ b/secure_cloudfront_video/settings/production.py
@@ -10,4 +10,15 @@ def plugin_settings(settings):
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
-    pass
+    settings.SCV_CLOUDFRONT_ID = getattr(settings, 'ENV_TOKENS', {}).get(
+        'SCV_CLOUDFRONT_ID',
+        settings.SCV_CLOUDFRONT_ID,
+    )
+    settings.SCV_CLOUDFRONT_URL = getattr(settings, 'ENV_TOKENS', {}).get(
+        'SCV_CLOUDFRONT_URL',
+        settings.SCV_CLOUDFRONT_URL,
+    )
+    settings.SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY = getattr(settings, 'AUTH_TOKENS', {}).get(
+        'SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY',
+        settings.SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY,
+    )

--- a/secure_cloudfront_video/urls.py
+++ b/secure_cloudfront_video/urls.py
@@ -15,10 +15,11 @@ Including another URLconf
 """
 from django.conf.urls import url
 
+from secure_cloudfront_video.views import secure_cloudfront_video
 
 urlpatterns = [
     url(
-        r'^secure-cloudfront-video/$',
+        r'',
         secure_cloudfront_video,
         name='secure_cloudfront_video',
     ),

--- a/secure_cloudfront_video/utils.py
+++ b/secure_cloudfront_video/utils.py
@@ -1,0 +1,47 @@
+"""
+Module containing helper and util functions for Amazon Cloudfront signed resource URLs views.
+"""
+from datetime import datetime, timedelta
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from django.conf import settings
+from django.http import Http404
+
+from secure_cloudfront_video.exceptions import MissingCloudFrontInformationError
+
+
+def cloudfront_rsa_signer(message):
+    """
+    Its only input parameter will be the message to be signed,
+    and its output will be the signed content as a binary string.
+    The hash algorithm needed by CloudFront is SHA-1.
+
+    More info: https://github.com/boto/botocore/blob/develop/botocore/signers.py#L274
+
+    Returns:
+        String that contains the signed private key.
+    """
+    cloudfront_key = str(getattr(settings, 'SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY', ''))
+
+    if not cloudfront_key:
+        raise MissingCloudFrontInformationError('Missing CloudFront private signing key.')
+
+    private_key = serialization.load_pem_private_key(
+        data=cloudfront_key,
+        password=None,
+        backend=default_backend(),
+    )
+
+    return private_key.sign(message, padding.PKCS1v15(), hashes.SHA1())
+
+
+def utc_time_plus_one_minute():
+    """
+    Return the UTC now time plus one minute.
+
+    Returns:
+        datetime.datetime instance that contains the UTC time plus one minute.
+    """
+    return datetime.utcnow() + timedelta(minutes=1)

--- a/secure_cloudfront_video/views.py
+++ b/secure_cloudfront_video/views.py
@@ -1,0 +1,57 @@
+"""
+Amazon Cloudfront signed Video URLs.
+"""
+import logging
+
+from botocore.signers import CloudFrontSigner
+from django.conf import settings
+from django.contrib.auth.decorators import login_required
+from django.http import Http404
+from django.shortcuts import redirect
+
+from secure_cloudfront_video.exceptions import MissingCloudFrontInformationError
+from secure_cloudfront_video.utils import cloudfront_rsa_signer, utc_time_plus_one_minute
+
+log = logging.getLogger(__name__)
+
+
+@login_required(redirect_field_name='dashboard')
+def secure_cloudfront_video(request):
+    """
+    Generate a redirect to the AWS CloudFront resource.
+
+    The signed resource URL must point to /secure-cloudfront-video/?key=path-to-aws-resource
+    The resource URL will have a expiration time of one minute.
+    Note that the resource URL must have the slash at the beginning of the string.
+
+    **Example Requests**:
+
+        GET lms-url/secure-cloudfront-video/?key=path-to-aws-resource
+
+    **Responses**
+        Redirect 302: If the signing process was successful and the resource exists.
+        Not Found 404: If the 'key' query string or any of the Amazon Cloud Front settings is missing.
+    """
+    meta = request.META
+
+    if not meta or meta.get('HTTP_HOST', '') not in meta.get('HTTP_REFERER', ''):
+        raise Http404
+
+    key = request.GET.get('key', '')
+    cloudfront_url = getattr(settings, 'SCV_CLOUDFRONT_URL', '')
+    cloudfront_id = getattr(settings, 'SCV_CLOUDFRONT_ID', '')
+
+    if not (key and cloudfront_url and cloudfront_id):
+        raise Http404
+
+    try:
+        cloudfront_signer = CloudFrontSigner(cloudfront_id, cloudfront_rsa_signer)
+        redirect_url = cloudfront_signer.generate_presigned_url(
+            url='{}{}'.format(cloudfront_url, key),
+            date_less_than=utc_time_plus_one_minute(),
+        )
+    except MissingCloudFrontInformationError as cloudfront_error:
+        log.error(cloudfront_error.message)
+        raise Http404
+
+    return redirect(redirect_url)


### PR DESCRIPTION
## Description:

This PR adds a new endpoint to sign URLs related to any resource in Amazon CloudFront service.

## Previous work:

https://github.com/proversity-org/edx-platform/pull/1036

## Configure:

ENV_TOKENS:

- SCV_CLOUDFRONT_ID = 'your-cloudfront-project-id'
- SCV_CLOUDFRONT_URL = 'your-cloudfront-url-containing-the-slash-at-the-end'

AUTH_TOKENS

- SCV_CLOUDFRONT_PRIVATE_SIGNING_KEY = 'cloudfront-private-signing-key'

## Reviewers:

- [ ] @andrey-canon 